### PR TITLE
Fixed an OutOfMemoryError when a GUI is open for too long

### DIFF
--- a/src/main/java/neresources/nei/NEIAdvSeedHandler.java
+++ b/src/main/java/neresources/nei/NEIAdvSeedHandler.java
@@ -89,8 +89,7 @@ public class NEIAdvSeedHandler extends TemplateRecipeHandler
         else
             toPrint = String.format("%2.2f", chance * 100).replace(",", ".") + "%";
 
-        Font font = new Font(false);
-        font.print(toPrint, 56, Y + 20);
+        Font.normal.print(toPrint, 56, Y + 20);
 
         cachedAbstract.cycleOutput(cycleticks);
     }

--- a/src/main/java/neresources/nei/NEIDungeonHandler.java
+++ b/src/main/java/neresources/nei/NEIDungeonHandler.java
@@ -119,11 +119,10 @@ public class NEIDungeonHandler extends TemplateRecipeHandler
     {
         CachedDungeonChest cachedChest = (CachedDungeonChest) arecipes.get(recipe);
 
-        Font font = new Font(false);
-        font.print(TranslationHelper.translateToLocal(cachedChest.chest.getName()), 60, 7);
-        font.print(DungeonRegistry.getInstance().getNumStacks(cachedChest.chest), 60, 20);
+        Font.normal.print(TranslationHelper.translateToLocal(cachedChest.chest.getName()), 60, 7);
+        Font.normal.print(DungeonRegistry.getInstance().getNumStacks(cachedChest.chest), 60, 20);
         if (cachedChest.lastSet > 0)
-            font.print(TranslationHelper.getLocalPageInfo(cachedChest.set, cachedChest.lastSet), 60, 36);
+            Font.normal.print(TranslationHelper.getLocalPageInfo(cachedChest.set, cachedChest.lastSet), 60, 36);
 
         int x = X_FIRST_ITEM + 18;
         int y = Y_FIRST_ITEM + (10 - Settings.ITEMS_PER_COLUMN);
@@ -133,7 +132,7 @@ public class NEIDungeonHandler extends TemplateRecipeHandler
             double chance = cachedChest.getChances()[i] * 100;
             String format = chance < 100 ? "%2.1f" : "%2.0f";
             String toPrint = String.format(format, chance).replace(',', '.') + "%";
-            font.print(toPrint, x, y);
+            Font.normal.print(toPrint, x, y);
             y += SPACING_Y;
             if (y >= Y_FIRST_ITEM + SPACING_Y * Settings.ITEMS_PER_COLUMN)
             {

--- a/src/main/java/neresources/nei/NEIEnchantmentHandler.java
+++ b/src/main/java/neresources/nei/NEIEnchantmentHandler.java
@@ -64,17 +64,16 @@ public class NEIEnchantmentHandler extends TemplateRecipeHandler
     public void drawExtras(int recipe)
     {
         CachedEnchantment cachedEnchantment = (CachedEnchantment) arecipes.get(recipe);
-        Font font = new Font(false);
         int y = FIRST_ENCHANT_Y;
         for (EnchantmentEntry enchantment : cachedEnchantment.getEnchantments())
         {
-            font.print(enchantment.getTranslatedWithLevels(), ENCHANT_X, y);
+            Font.normal.print(enchantment.getTranslatedWithLevels(), ENCHANT_X, y);
             y += SPACING_Y;
         }
         if (cachedEnchantment.lastSet > 0)
         {
             String toPrint = TranslationHelper.getLocalPageInfo(cachedEnchantment.set, cachedEnchantment.lastSet);
-            font.print(toPrint, PAGE_X, PAGE_Y);
+            Font.normal.print(toPrint, PAGE_X, PAGE_Y);
         }
 
         cachedEnchantment.cycleOutput(cycleticks);

--- a/src/main/java/neresources/nei/NEIMobHandler.java
+++ b/src/main/java/neresources/nei/NEIMobHandler.java
@@ -134,22 +134,21 @@ public class NEIMobHandler extends TemplateRecipeHandler
     {
         CachedMob cachedMob = (CachedMob) arecipes.get(recipe);
 
-        Font font = new Font(false);
-        font.print(cachedMob.mob.getMobName(), 2, 2);
-        font.print(TranslationHelper.translateToLocal("ner.mob.biome"), 2, 12);
-        font.print(cachedMob.mob.getLightLevel(), 2, 22);
-        font.print(TranslationHelper.translateToLocal("ner.mob.exp") + ": " + MobHelper.getExpDrop(cachedMob.mob), 2, 32);
+        Font.normal.print(cachedMob.mob.getMobName(), 2, 2);
+        Font.normal.print(TranslationHelper.translateToLocal("ner.mob.biome"), 2, 12);
+        Font.normal.print(cachedMob.mob.getLightLevel(), 2, 22);
+        Font.normal.print(TranslationHelper.translateToLocal("ner.mob.exp") + ": " + MobHelper.getExpDrop(cachedMob.mob), 2, 32);
 
         int y = Y_FIRST_ITEM + 4;
         for (int i = cachedMob.set * Settings.ITEMS_PER_COLUMN; i < cachedMob.set * Settings.ITEMS_PER_COLUMN + Settings.ITEMS_PER_COLUMN; i++)
         {
             if (i >= cachedMob.mob.getDrops().length) break;
-            font.print(cachedMob.mob.getDrops()[i].toString(), X_FIRST_ITEM + 18, y);
+            Font.normal.print(cachedMob.mob.getDrops()[i].toString(), X_FIRST_ITEM + 18, y);
             y += SPACING_Y;
         }
 
         if (cachedMob.lastSet > 0)
-            font.print(TranslationHelper.getLocalPageInfo(cachedMob.set, cachedMob.lastSet), X_FIRST_ITEM, 120);
+            Font.normal.print(TranslationHelper.getLocalPageInfo(cachedMob.set, cachedMob.lastSet), X_FIRST_ITEM, 120);
 
         cachedMob.cycleOutputs(cycleticks, recipe);
     }

--- a/src/main/java/neresources/nei/NEIOreHandler.java
+++ b/src/main/java/neresources/nei/NEIOreHandler.java
@@ -110,8 +110,6 @@ public class NEIOreHandler extends TemplateRecipeHandler
         int maxY = cachedOre.oreMatchEntry.getMaxY() + Settings.EXTRA_RANGE;
         font.print(maxY > 255 ? 255 : maxY, X_OFFSPRING + X_AXIS_SIZE, Y_OFFSPRING + 2);
         font.print(TranslationHelper.translateToLocal("ner.ore.bestY") + ": " + cachedOre.oreMatchEntry.getBestY(), X_ITEM - 2, Y_ITEM + 20);
-
-        cachedOre.cycleItemStack(cycleticks);
     }
 
     @Override
@@ -159,22 +157,18 @@ public class NEIOreHandler extends TemplateRecipeHandler
     {
         private OreMatchEntry oreMatchEntry;
         private List<ItemStack> oresAndDrops;
-        private int current, last;
-        private long cycleAt;
 
         public CachedOre(OreMatchEntry oreMatchEntry)
         {
             this.oreMatchEntry = oreMatchEntry;
             this.oresAndDrops = oreMatchEntry.getOresAndDrops();
-            this.current = 0;
-            this.last = this.oresAndDrops.size() - 1;
-            this.cycleAt = -1;
         }
 
         @Override
         public PositionedStack getResult()
         {
-            return new PositionedStack(this.oresAndDrops.get(current), X_ITEM, Y_ITEM);
+            int index = (cycleticks / CYCLE_TIME) % this.oresAndDrops.size();
+            return new PositionedStack(this.oresAndDrops.get(index), X_ITEM, Y_ITEM);
         }
 
         public int getLineColor()
@@ -192,17 +186,6 @@ public class NEIOreHandler extends TemplateRecipeHandler
             for (ItemStack listStack : this.oresAndDrops)
                 if (listStack.isItemEqual(itemStack)) return true;
             return false;
-        }
-
-        public void cycleItemStack(long tick)
-        {
-            if (cycleAt == -1) cycleAt = tick + CYCLE_TIME;
-
-            if (tick >= cycleAt)
-            {
-                if (++current > last) current = 0;
-                cycleAt += CYCLE_TIME;
-            }
         }
     }
 }

--- a/src/main/java/neresources/nei/NEIOreHandler.java
+++ b/src/main/java/neresources/nei/NEIOreHandler.java
@@ -102,14 +102,13 @@ public class NEIOreHandler extends TemplateRecipeHandler
             yPrev = y;
         }
 
-        Font font = new Font(true);
-        font.print("0%", X_OFFSPRING - 10, Y_OFFSPRING - 7);
-        font.print(String.format("%.2f", max * 100) + "%", X_OFFSPRING - 20, Y_OFFSPRING - Y_AXIS_SIZE);
+        Font.small.print("0%", X_OFFSPRING - 10, Y_OFFSPRING - 7);
+        Font.small.print(String.format("%.2f", max * 100) + "%", X_OFFSPRING - 20, Y_OFFSPRING - Y_AXIS_SIZE);
         int minY = cachedOre.oreMatchEntry.getMinY() - Settings.EXTRA_RANGE;
-        font.print(minY < 0 ? 0 : minY, X_OFFSPRING - 3, Y_OFFSPRING + 2);
+        Font.small.print(minY < 0 ? 0 : minY, X_OFFSPRING - 3, Y_OFFSPRING + 2);
         int maxY = cachedOre.oreMatchEntry.getMaxY() + Settings.EXTRA_RANGE;
-        font.print(maxY > 255 ? 255 : maxY, X_OFFSPRING + X_AXIS_SIZE, Y_OFFSPRING + 2);
-        font.print(TranslationHelper.translateToLocal("ner.ore.bestY") + ": " + cachedOre.oreMatchEntry.getBestY(), X_ITEM - 2, Y_ITEM + 20);
+        Font.small.print(maxY > 255 ? 255 : maxY, X_OFFSPRING + X_AXIS_SIZE, Y_OFFSPRING + 2);
+        Font.small.print(TranslationHelper.translateToLocal("ner.ore.bestY") + ": " + cachedOre.oreMatchEntry.getBestY(), X_ITEM - 2, Y_ITEM + 20);
     }
 
     @Override

--- a/src/main/java/neresources/nei/NEIOreHandler.java
+++ b/src/main/java/neresources/nei/NEIOreHandler.java
@@ -88,13 +88,17 @@ public class NEIOreHandler extends TemplateRecipeHandler
             if (d > max) max = d;
         double xPrev = X_OFFSPRING;
         double yPrev = Y_OFFSPRING;
-        double space = X_AXIS_SIZE / (array.length * 1D);
-        for (double value : array)
+        double space = X_AXIS_SIZE / ((array.length - 1) * 1D);
+        for (int i = 0; i < array.length; i++)
         {
-            double x = xPrev + space;
-            int y = Y_OFFSPRING - (int) ((value / max) * Y_AXIS_SIZE);
-            RenderHelper.drawLine(xPrev, yPrev, x, y, cachedOre.getLineColor());
-            xPrev = x;
+            double value = array[i];
+            double y = Y_OFFSPRING - ((value / max) * Y_AXIS_SIZE);
+            if (i > 0) // Only draw a line after the first element (cannot draw line with only one point)
+            {
+                double x = xPrev + space;
+                RenderHelper.drawLine(xPrev, yPrev, x, y, cachedOre.getLineColor());
+                xPrev = x;
+            }
             yPrev = y;
         }
 
@@ -113,6 +117,8 @@ public class NEIOreHandler extends TemplateRecipeHandler
     @Override
     public List<String> handleTooltip(GuiRecipe gui, List<String> currenttip, int recipe)
     {
+        currenttip = super.handleTooltip(gui, currenttip, recipe);
+
         if (GuiContainerManager.shouldShowTooltip(gui) && currenttip.size() == 0)
         {
             Point offset = gui.getRecipePosition(recipe);
@@ -126,12 +132,10 @@ public class NEIOreHandler extends TemplateRecipeHandler
                 float[] chances = cachedOre.oreMatchEntry.getChances();
                 double space = X_AXIS_SIZE / (chances.length * 1D);
                 // Calculate the hovered over y value
-                int yValue = (int) ((relMouse.x - X_OFFSPRING) / space);
-                if (yValue > 0 && yValue < chances.length)
-                {
-                    //TODO: The shift of one element here is due to some minor inaccuracy in the drawing function and could be avoided
-                    currenttip.add("Y: " + yValue + String.format(" (%.2f%%)", chances[yValue - 1] * 100));
-                }
+                int index = (int) ((relMouse.x - X_OFFSPRING) / space);
+                int yValue = Math.max(0, index + cachedOre.oreMatchEntry.getMinY() - Settings.EXTRA_RANGE + 1);
+                if (index >= 0 && index < chances.length)
+                    currenttip.add("Y: " + yValue + String.format(" (%.2f%%)", chances[index] * 100));
             }
         }
         return currenttip;

--- a/src/main/java/neresources/utils/Font.java
+++ b/src/main/java/neresources/utils/Font.java
@@ -7,9 +7,12 @@ import net.minecraft.client.resources.IReloadableResourceManager;
 
 public class Font
 {
+    public final static Font small = new Font(true);
+    public final static Font normal = new Font(false);
+
     private FontRenderer fontRenderer;
 
-    public Font(boolean small)
+    private Font(boolean small)
     {
         Minecraft mc = Minecraft.getMinecraft();
         fontRenderer = new FontRenderer(mc.gameSettings, Resources.Vanilla.FONT, mc.getTextureManager(), small);


### PR DESCRIPTION
I changed the font functions to be static in order to prevent a memory leak which occurred whenever a GUI is open for too long.

The other changes slightly alter how the Ore Gen is drawn, again. (I'm still not quite satisfied with the result though.)