### PR TITLE
Fixes NPE when latest Reliquary, NER and Galacticraft are in the same…

### DIFF
--- a/src/main/java/neresources/compatibility/reliquary/ReliquaryCompat.java
+++ b/src/main/java/neresources/compatibility/reliquary/ReliquaryCompat.java
@@ -112,8 +112,7 @@ public class ReliquaryCompat extends CompatBase
         //Charged Creeper
         DropItem eye_of_the_storm = new DropItem(XRRecipes.ingredient(Reference.STORM_INGREDIENT_META), 1, 1, eventHandler.getBaseDrop(Names.eye_of_the_storm), Conditional.playerKill);
         EntityCreeper chargedCreeper = new EntityCreeper(world);
-        chargedCreeper.onStruckByLightning(null);
-        chargedCreeper.extinguish();
+        chargedCreeper.getDataWatcher().updateObject(17, (byte) 1);
         registerMob(new MobEntry(chargedCreeper, LightLevel.hostile, eye_of_the_storm));
 
         //Enderman


### PR DESCRIPTION
See this stack trace pastebin http://pastebin.com/bf16z2LD 

Basically the lightning bolt was null when charged creeper got created and struck by this null lightning and Galacticraft wasn't prepared for the source of attack to be null. 

Replaced with datawatcher update to just set the powered bit which is cleaner anyway
